### PR TITLE
Bump PlantUML version

### DIFF
--- a/doclet/build.gradle
+++ b/doclet/build.gradle
@@ -3,7 +3,7 @@ archivesBaseName = 'pegdown-doclet'
 dependencies {
     compile group:'org.pegdown', name:'pegdown', version:'1.4.1'
     compile group:'com.google.guava', name:'guava', version:'18.0'
-    compile group:'net.sourceforge.plantuml', name:'plantuml', version:'8007'
+    compile group:'net.sourceforge.plantuml', name:'plantuml', version:'8032'
 
     provided project.ext.jdkTools
 }


### PR DESCRIPTION
Bump the PlantUML version (to the current) to avoid the error "Package can be only linked to other package" in certain documents.