### PR TITLE
(#22) Support generic type parameters on methods

### DIFF
--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/ParamTagRenderer.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/ParamTagRenderer.java
@@ -35,7 +35,16 @@ public class ParamTagRenderer implements TagRenderer<ParamTag> {
     @Override
     public void render(ParamTag tag, StringBuilder target, PegdownDoclet doclet) {
         target.append(tag.name())
-                .append(' ').append(tag.parameterName())
+                .append(' ').append(renderParameterName(tag))
                 .append(' ').append(simplifySingleParagraph(doclet.toHtml(tag.parameterComment())));
+    }
+
+    private static String renderParameterName(ParamTag tag) {
+        if (!tag.isTypeParameter()) {
+            return tag.parameterName();
+        }
+        else {
+            return '<' + tag.parameterName() + '>';
+        }
     }
 }

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/ParamTagRendererSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/ParamTagRendererSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013 Raffael Herzog
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown
+
+import com.sun.javadoc.ParamTag
+import com.sun.javadoc.RootDoc
+import spock.lang.Specification
+import sun.reflect.generics.tree.TypeTree
+
+/**
+ * @author Sebastian Lövdahl
+ */
+class ParamTagRendererSpec extends Specification {
+
+    private String result
+
+    def "Test normal parameter"() {
+        when:
+            result = render "String", "the string to check"
+        then:
+            result == "@param String the string to check"
+    }
+
+    def "Test single-letter generic type"() {
+        when:
+            result = render "<T>", "the type of the parameter"
+        then:
+            result == "@param <T> the type of the parameter"
+    }
+
+    def "Test multiple letter generic type"() {
+        when:
+        result = render "<TYPE>", "the type of the parameter"
+        then:
+        result == "@param <TYPE> the type of the parameter"
+    }
+
+    private String render(String type, String text, Options options=new Options()) {
+        return render(param(type, text), options)
+    }
+
+    private String render(ParamTag tag, Options options=new Options()) {
+        def doclet = new PegdownDoclet(options, Stub(RootDoc))
+        def buf = new StringBuilder()
+        new ParamTagRenderer().render(tag, buf, doclet)
+        return buf.toString()
+    }
+
+    private ParamTag param(String type, String text) {
+        def tag = Mock(ParamTag)
+        tag.name() >> "@param"
+        tag.parameterComment() >> text
+        if (type.startsWith('<')) {
+            tag.parameterName() >> type.substring(1, type.length() - 1)
+            tag.isTypeParameter() >> true
+        }
+        else {
+            tag.parameterName() >> type
+            tag.isTypeParameter() >> false
+        }
+        return tag
+    }
+}


### PR DESCRIPTION
The com.sun.tools.javadoc.ParamTagImpl returns the parameter name without the < and > signs, therefore they need to be re-added.

ParamTagImpl constructor confirming the behaviour:
```java
ParamTagImpl(DocImpl holder, String name, String text) {
    super(holder, name, text);
    String[] sa = this.divideAtWhite();
    Matcher m = typeParamRE.matcher(sa[0]);
    this.isTypeParameter = m.matches();
    this.parameterName = this.isTypeParameter?m.group(1):sa[0];
    this.parameterComment = sa[1];
}
```