### PR TITLE
added support for android

### DIFF
--- a/integrations/gradle-plugin/build.gradle
+++ b/integrations/gradle-plugin/build.gradle
@@ -3,4 +3,6 @@ apply plugin:'groovy'
 dependencies {
     compile gradleApi()
     compile localGroovy()
+
+    testCompile 'com.android.tools.build:gradle:1.3.0'
 }

--- a/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
+++ b/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
@@ -8,8 +8,8 @@ class PegdownDocletPlugin implements Plugin<Project> {
     final def CONFIGURATION_NAME = "pegdownDoclet"
 
     void apply(Project project) {
-        // make sure the java plugin is applied
-        project.plugins.apply('java')
+        // make sure the java dependencies are available
+        ensureJavaAvailable(project)
 
         // create a new configuration for the doclet dependency
         def config = project.configurations.create(CONFIGURATION_NAME)
@@ -31,6 +31,15 @@ class PegdownDocletPlugin implements Plugin<Project> {
                     addStringOption("parse-timeout", "10")
                 }
             }
+        }
+    }
+
+    private void ensureJavaAvailable(Project project) {
+        boolean hasAndroidLib = project.pluginManager.hasPlugin('com.android.library')
+        boolean hasAndroidApp = project.pluginManager.hasPlugin('com.android.application')
+        boolean hasJava = project.pluginManager.hasPlugin('java')
+        if(!hasJava && !hasAndroidLib && !hasAndroidApp) {
+            throw new IllegalStateException("one of following plugins must be applied before pegdown-doclet: [java, com.android.library, com.android.application]")
         }
     }
 }

--- a/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
+++ b/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
@@ -18,7 +18,7 @@ class PegdownDocletPlugin implements Plugin<Project> {
         def pegdownVersion = new InputStreamReader(PegdownDocletPlugin.class.getResourceAsStream('version.txt')).withReader { reader ->
             reader.text.trim()
         }
-        project.dependencies.add(CONFIGURATION_NAME, "ch.raffael.pegdown-doclet:pegdown-doclet:$pegdownVersion")
+        project.dependencies.add(CONFIGURATION_NAME, "ch.raffael.pegdown-doclet:$project.name:$pegdownVersion")
 
         // after the user buildscript is evaluated ...
         project.gradle.projectsEvaluated {

--- a/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
+++ b/integrations/gradle-plugin/src/main/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPlugin.groovy
@@ -18,7 +18,7 @@ class PegdownDocletPlugin implements Plugin<Project> {
         def pegdownVersion = new InputStreamReader(PegdownDocletPlugin.class.getResourceAsStream('version.txt')).withReader { reader ->
             reader.text.trim()
         }
-        project.dependencies.add(CONFIGURATION_NAME, "ch.raffael.pegdown-doclet:$project.name:$pegdownVersion")
+        project.dependencies.add(CONFIGURATION_NAME, "ch.raffael.pegdown-doclet:gradle-plugin:$pegdownVersion")
 
         // after the user buildscript is evaluated ...
         project.gradle.projectsEvaluated {

--- a/integrations/gradle-plugin/src/test/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPluginTest.groovy
+++ b/integrations/gradle-plugin/src/test/groovy/ch/raffael/doclets/pegdown/integrations/gradle/PegdownDocletPluginTest.groovy
@@ -1,0 +1,55 @@
+package ch.raffael.doclets.pegdown.integrations.gradle;
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.Upload;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Before
+import org.junit.Ignore;
+import org.junit.Test
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail;
+
+/**
+ * @since 2015-12-15
+ */
+public class PegdownDocletPluginTest {
+    private Project project;
+
+    @Before
+    public void setup() {
+        project = ProjectBuilder.builder().build()
+    }
+
+    @Test
+    public void should_fail_if_no_java_in_classpath() {
+        try{
+            project.pluginManager.apply PegdownDocletPlugin
+        }catch (IllegalStateException ie) {
+            assertTrue(ie.message.contains("one of following plugins must be applied"))
+        }
+        fail("expected exception")
+    }
+
+    @Test
+    public void should_run_with_java_plugin() {
+        project.pluginManager.apply 'java'
+        project.pluginManager.apply PegdownDocletPlugin
+    }
+
+    @Test
+    public void should_run_with_android_application_plugin() {
+        project.pluginManager.apply 'com.android.application'
+        project.pluginManager.apply PegdownDocletPlugin
+    }
+
+    @Test
+    public void should_run_with_android_library_plugin() {
+        project.pluginManager.apply 'com.android.library'
+        project.pluginManager.apply PegdownDocletPlugin
+    }
+
+
+}


### PR DESCRIPTION
Hi Raffael,

habe das ganze noch minimaler gelöst. Ich prüfe nur noch ob eines der notwendigen plugins bereits im pluginmanager vorhanden ist. Falls nicht fliegt eine Exception. Das ist weniger restriktiv als explizit das java plugin per apply zu erzwingen.

Leider bekomme ich das ganze nicht getestet, das plugin scheint trotz lokalem deploy nicht gefunden zu werden. 
