### PR TITLE
Gist inline tag (issue #58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ run/
 
 # exclude build settings
 local.properties
+
+.idea/
+*.ipr
+*.iws
+*.iml

--- a/doclet/build.gradle
+++ b/doclet/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile libs.plantuml
     compileOnly libs.jdkTools
 
+    compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.6'
+
     testCompile group: 'org.jsoup', name: 'jsoup', version: '1.8.3'
 }
 

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/Options.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Raffael Herzog
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
  *
  * This file is part of pegdown-doclet.
  *
@@ -18,18 +18,6 @@
  */
 package ch.raffael.doclets.pegdown;
 
-import java.io.File;
-import java.lang.reflect.Field;
-import java.math.BigDecimal;
-import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.regex.Pattern;
-
 import com.google.common.base.Splitter;
 import com.sun.javadoc.DocErrorReporter;
 import com.sun.tools.doclets.standard.Standard;
@@ -37,6 +25,14 @@ import org.pegdown.Extensions;
 import org.pegdown.LinkRenderer;
 import org.pegdown.PegDownProcessor;
 import org.pegdown.ToHtmlSerializer;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.util.*;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -99,7 +95,6 @@ public class Options {
     private String todoTitle = null;
 
     private LinkRenderer linkRenderer = null;
-    private PegDownProcessor processor = null;
 
     public Options() {
     }
@@ -259,7 +254,6 @@ public class Options {
      */
     public void setPegdownExtensions(int pegdownExtensions) {
         this.pegdownExtensions = pegdownExtensions;
-        processor = null;
     }
 
     /**
@@ -443,7 +437,6 @@ public class Options {
      * @see PegDownProcessor#PegDownProcessor(int, long)
      */
     public long getParseTimeout() {
-        processor = null;
         return parseTimeout != null ? parseTimeout : PegDownProcessor.DEFAULT_MAX_PARSING_TIME;
     }
 
@@ -456,54 +449,6 @@ public class Options {
      */
     public void setParseTimeout(long parseTimeout) {
         this.parseTimeout = parseTimeout;
-    }
-
-    /**
-     * Converts Markdown source to HTML according to this options object. Leading spaces
-     * will be fixed.
-     *
-     * @param markup    The Markdown source.
-     *
-     * @return The resulting HTML.
-     *
-     * @see #toHtml(String, boolean)
-     */
-    public String toHtml(String markup) {
-        return toHtml(markup, true);
-    }
-
-    /**
-     * Converts Markdown source to HTML according to this options object. If
-     * `fixLeadingSpaces` is `true`, exactly one leading whitespace character ('\\u0020')
-     * will be removed, if it exists.
-     *
-     * @todo This method doesn't belong here, move it to {@link PegdownDoclet}.
-     *
-     * @param markup           The Markdown source.
-     * @param fixLeadingSpaces `true` if leading spaces should be fixed.
-     *
-     * @return The resulting HTML.
-     */
-    public String toHtml(String markup, boolean fixLeadingSpaces) {
-        if ( processor == null ) {
-            processor = createProcessor();
-        }
-        if ( fixLeadingSpaces ) {
-            markup = LINE_START.matcher(markup).replaceAll("");
-        }
-        List<String> tags = new ArrayList<>();
-        String html = createDocletSerializer().toHtml(processor.parseMarkdown(Tags.extractInlineTags(markup, tags).toCharArray()));
-        return Tags.insertInlineTags(html, tags);
-    }
-
-    /**
-     * Create a new processor. If you need to further customise the markup processing,
-     * you can override this method.
-     *
-     * @return A (possibly customised) Pegdown processor.
-     */
-    protected PegDownProcessor createProcessor() {
-        return new PegDownProcessor(firstNonNull(pegdownExtensions, DEFAULT_PEGDOWN_EXTENSIONS), getParseTimeout());
     }
 
     /**

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/PegdownDoclet.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/PegdownDoclet.java
@@ -18,6 +18,8 @@
  */
 package ch.raffael.doclets.pegdown;
 
+import ch.raffael.doclets.pegdown.inlinetag.InlineTagRender;
+import ch.raffael.doclets.pegdown.inlinetag.InlineTagRenders;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.sun.javadoc.*;
@@ -64,6 +66,7 @@ public class PegdownDoclet implements DocErrorReporter {
 
     private LinkRenderer linkRenderer = null;
     private PegDownProcessor processor = null;
+    private InlineTagRender inlineTagRenders = null;
 
 
     /**
@@ -425,9 +428,18 @@ public class PegdownDoclet implements DocErrorReporter {
             markup = LINE_START.matcher(markup).replaceAll("");
         }
 
+        markup = renderInlineTags(markup);
+
         List<String> tags = new ArrayList<>();
         String html = createDocletSerializer().toHtml(processor.parseMarkdown(Tags.extractInlineTags(markup, tags).toCharArray()));
         return Tags.insertInlineTags(html, tags);
+    }
+
+    private String renderInlineTags(String markup) {
+        if( this.inlineTagRenders==null ) {
+            this.inlineTagRenders = InlineTagRenders.standardRenders(this.options);
+        }
+        return this.inlineTagRenders.render(markup);
     }
 
     /**

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRender.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRender.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag;
+
+/**
+ * InlineTagRender is responsible for render the markup (searching the custom inline tag) and convert it to markdown.
+ */
+public interface InlineTagRender {
+    /**
+     * Renders the markup to markdown using a taglets content.
+     *
+     * @param markup the markup
+     * @return the markdown or if there is no taglet the orgin markup will be returned.
+     */
+    String render(String markup);
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenderCollector.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenderCollector.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.raffael.doclets.pegdown.inlinetag;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * InlineTagRenderCollector applies the origin markdown on all {@linkplain #register(InlineTagRender) registered}
+ * {@link InlineTagRender}s.
+ */
+final class InlineTagRenderCollector implements InlineTagRender {
+
+    private final List<InlineTagRender> renderer=new LinkedList<>();
+
+    InlineTagRenderCollector() {}
+
+    InlineTagRenderCollector register(InlineTagRender inlineTagRender) {
+        this.renderer.add(inlineTagRender);
+        return this;
+    }
+
+    @Override
+    public String render(final String markup) {
+        String markdown=markup;
+        for (InlineTagRender inlineTagRender : renderer) {
+            markdown= inlineTagRender.render(markdown);
+        }
+        return markdown;
+    }
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenders.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenders.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag;
+
+import ch.raffael.doclets.pegdown.Options;
+import ch.raffael.doclets.pegdown.inlinetag.gist.GistTagRenderAssembler;
+
+/**
+ * InlineTagRenders provides factory methods for creating {@link InlineTagRender}.
+ */
+public abstract class InlineTagRenders {
+    private InlineTagRenders() {
+    }
+
+    /**
+     * The standard {@link InlineTagRender} containing currently:
+     *
+     * + {@link ch.raffael.doclets.pegdown.inlinetag.gist.GistTagRender}
+     *
+     * @param options the options.
+     *
+     * @return the standard {@link InlineTagRender}.
+     */
+    public static InlineTagRender standardRenders(Options options) {
+        return new InlineTagRenderCollector()                               //
+                   .register(GistTagRenderAssembler.createInlineTagRender(options));  //
+    }
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/TagContentConverter.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/TagContentConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag;
+
+/**
+ * TagContentConverter is responsible for converting the tagContent to markdown.
+ *
+ * The tag content converter will be called by {@link InlineTagRender#render(String)}, if the
+ * custom tag could be found.
+ *
+ * @see InlineTagRender
+ */
+public interface TagContentConverter {
+
+    /**
+     * Convert the tag content to markdown - resolved by {@link InlineTagRender#render(String)}.
+     * @param tagContent the tag content
+     * @return the markdown.
+     */
+    String markdown(String tagContent);
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistClient.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistClient.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import java.util.List;
+
+/**
+ * GistClient is responsible for ...
+ */
+interface GistClient {
+    List<GistItem> resolveGists(String gistid);
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistItem.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistItem.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import java.util.Objects;
+
+/**
+ * GistItem is responsible for ...
+ */
+final class GistItem {
+    final String id;
+    final String htmlUrl;
+    final String filename;
+    final String language;
+    final String rawUrl;
+    final String content;
+
+    GistItem(String id, String htmlUrl, String filename, String language, String rawUrl, String content) {
+        this.id = id;
+        this.htmlUrl = htmlUrl;
+        this.language = language;
+        this.rawUrl = rawUrl;
+        this.filename = filename;
+        this.content = content;
+    }
+
+    static GistItem createErrorGistItem(String id, String url, String errorMessage) {
+        return new GistItem(id, url, "unknown", "", url, errorMessage);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GistItem)) return false;
+        GistItem gistItem = (GistItem) o;
+        return Objects.equals(id, gistItem.id) &&
+                Objects.equals(filename, gistItem.filename);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, filename, rawUrl);
+    }
+
+
+    @Override
+    public String toString() {
+        return "GistItem{" +
+                "id='" + id + '\'' +
+                ", htmlUrl='" + htmlUrl + '\'' +
+                ", filename='" + filename + '\'' +
+                ", rawUrl='" + rawUrl + '\'' +
+                '}';
+    }
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistRestClient.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistRestClient.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import groovy.json.JsonSlurper;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * GistClient is responsible for loading the gists from Github using Github's REST API.
+ */
+final class GistRestClient implements GistClient {
+
+    private static final String HTTPS_API_GITHUB_COM_GISTS = "https://api.github.com/gists/";
+    private static final GistRestClient STANDARD_GIST_CLIENT = new GistRestClient();
+
+    private final JsonSlurper jsonSlurper = new JsonSlurper();
+    private final URL url;
+    private final String gistId;
+
+    private GistRestClient() {
+        this((URL) null, "no-gist");
+    }
+
+    /**
+     * Package private for testing purposes.
+     *
+     * @param url    the URL
+     * @param gistId the gistid
+     */
+    GistRestClient(URL url, String gistId) {
+        this.url = url;
+        this.gistId = gistId;
+    }
+
+    static GistClient standardGistClient() {
+        return STANDARD_GIST_CLIENT;
+    }
+
+    private static URL createGithubUrl(String gistId) throws MalformedURLException {
+        return new URL(toUrlString(gistId));
+    }
+
+    private static String toUrlString(String gistId) {
+        return HTTPS_API_GITHUB_COM_GISTS + gistId.trim();
+    }
+
+    List<GistItem> resolveGists() {
+        if (url == null) {
+            throw new IllegalStateException("Please use resolveGists(<gistid>)");
+        }
+        try {
+            return this.doResolveGistItemsFromURL();
+        }
+        catch (IllegalArgumentException e) {
+            e.printStackTrace(System.err);
+            return Collections.singletonList(GistItem.createErrorGistItem(gistId, toUrlString(gistId), "Parse error: " + e.getMessage()));
+        }
+        catch (Exception e) {
+            e.printStackTrace(System.err);
+            return Collections.singletonList(GistItem.createErrorGistItem(gistId, toUrlString(gistId), "No gist found for gistid '" + gistId + "'"));
+        }
+    }
+
+
+    @Override
+    public List<GistItem> resolveGists(String gistId) {
+        try {
+            return new GistRestClient(createGithubUrl(gistId), gistId).resolveGists();
+        } catch (Exception e) {
+            throw new RuntimeException("Caught unexpected exception", e);
+        }
+    }
+
+    private List<GistItem> doResolveGistItemsFromURL() throws Exception {
+        final Map<String, ?> response = getRootJsonObject(jsonSlurper.parse(url, "UTF-8"), Object.class);
+        final String id = getStringValue(response, "id");
+        final String htmlUrl = getStringValue(response, "html_url");
+        final Map<String, ?> files = getJsonObject(response, "files", Object.class);
+
+        return toGistItems(id, htmlUrl, files);
+    }
+
+    private List<GistItem> toGistItems(String id, String htmlUrl, Map<String, ?> files) {
+        final List<GistItem> gists = new LinkedList<>();
+        for (Object file : files.values()) {
+            @SuppressWarnings("unchecked")
+            final Map<String, ?> gist = typeSafe(file,"files",Map.class);
+
+            final String language = getStringValue(gist, "language");
+            final String filename = getStringValue(gist, "filename");
+            final String raw_url = getStringValue(gist, "raw_url");
+            final String content = getStringValue(gist, "content");
+
+            gists.add(new GistItem(id, htmlUrl, filename, language, raw_url, content));
+        }
+
+        return gists;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Map<String,?> getRootJsonObject(Object input, Class<T> clazz) {
+        return typeSafe(input, "root", Map.class);
+    }
+
+    private String getStringValue(Map<String, ?> jsonObject, String field) {
+        final Object value = getNullSafetyObject(jsonObject, field);
+        return typeSafe(value, field, String.class);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Map<String, T>  getJsonObject(Map<String, ?> jsonObject, String field, Class<T> clazz) {
+        final Object value = getNullSafetyObject(jsonObject, field);
+
+        if (!(value instanceof Map)) {
+            throw new IllegalArgumentException("Field '" + field + "' is not of type Map (a JSON object). " + githubChangeRestAPI());
+        }
+
+        return typeSafe(value, field, Map.class);
+
+    }
+
+    private Object getNullSafetyObject(Map<String, ?> jsonObject, String field) {
+        final Object value = jsonObject.get(field);
+        if( value==null ) {
+            throw new IllegalArgumentException(
+                    "Field '" + field + "' not found or value is null. " + githubChangeRestAPI()
+            );
+        }
+        return value;
+    }
+
+
+    private <T> T typeSafe(Object value, String field, Class<T> type) {
+        if (! type.isInstance(value)) {
+            throw new IllegalArgumentException(
+                    "Field '" + field + "' is not of type " + type.getSimpleName()
+                    + ". " + githubChangeRestAPI()
+                );
+        }
+        return type.cast(value);
+    }
+
+    private String githubChangeRestAPI() {
+        return "Github changes the for GIST-REST-API (using " + toUrlString(this.gistId) + ")";
+    }
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagContentConverter.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagContentConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import ch.raffael.doclets.pegdown.inlinetag.TagContentConverter;
+
+import java.util.List;
+
+/**
+ * GistTagContentConverter is responsible for ...
+ */
+final class GistTagContentConverter implements TagContentConverter {
+
+    private final GistClient gistClient;
+
+    GistTagContentConverter(GistClient gistClient) {
+        this.gistClient = gistClient;
+    }
+
+    @Override
+    public String markdown(String gistid) {
+        final StringBuilder result=new StringBuilder();
+        final List<GistItem> gists = gistClient.resolveGists(gistid);
+        boolean first=true;
+        for (GistItem gist : gists) {
+            if( ! first )
+                result.append("\n\n");
+            result.append(toMarkdown(gist));
+            first=false;
+        }
+        return result.toString();
+    }
+
+    private static String toMarkdown(GistItem gist) {
+        return "```" + gist.language.toLowerCase() + "\n" +
+                gist.content + "\n" +
+                "```" + "\n" +
+                "[Gist on Github](" + gist.htmlUrl + ")" +
+                " and " +
+                "[Raw File " + gist.filename + "](" + gist.rawUrl + ")";
+    }
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRender.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRender.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import ch.raffael.doclets.pegdown.inlinetag.InlineTagRender;
+import ch.raffael.doclets.pegdown.inlinetag.TagContentConverter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * GistTagRender is responsible for rendering the gist inline taglet.
+ */
+final class GistTagRender implements InlineTagRender {
+
+    private static final Pattern GIST_PATTERN=Pattern.compile("\\s*\\{\\@gist\\s+(?<gistid>[^}]*)\\}\\s*");
+    private static final Pattern EOL_PATTERN=Pattern.compile("\\s*+$");
+
+    private TagContentConverter tagContentConverter;
+
+    GistTagRender(TagContentConverter tagContentConverter) {
+        this.tagContentConverter = tagContentConverter;
+    }
+
+    @Override
+    public String render(String markup) {
+        final Matcher matcher = GIST_PATTERN.matcher(markup);
+        if( ! matcher.find() ) {
+            return markup;
+        }
+
+        matcher.reset();
+        return trimLines(replaceTags(matcher));
+    }
+
+    private String replaceTags(Matcher matcher) {
+        final StringBuffer result = new StringBuffer();
+        while(matcher.find()) {
+            final String gistid=matcher.group("gistid");
+            matcher.appendReplacement(result, resolveMarkdown(gistid));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private String resolveMarkdown(String gistid) {
+        return tagContentConverter.markdown(gistid);
+    }
+
+    private static String trimLines(String input) {
+        return EOL_PATTERN.matcher(input).replaceAll("");
+    }
+
+}

--- a/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRenderAssembler.java
+++ b/doclet/src/main/java/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRenderAssembler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag.gist;
+
+import ch.raffael.doclets.pegdown.Options;
+
+/**
+ * GistTagRenderAssembler is responsible for ...
+ */
+public final class GistTagRenderAssembler {
+    
+    public static GistTagRender createInlineTagRender(Options options) {
+        final GistClient gistClient=GistRestClient.standardGistClient();
+        final GistTagContentConverter markdownConverter = new GistTagContentConverter(gistClient);
+
+        return new GistTagRender(markdownConverter);
+    } 
+}

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenderCollectorSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/InlineTagRenderCollectorSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package ch.raffael.doclets.pegdown.inlinetag
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+/**
+ * InlineTagRenderCollector contains specification for ... .
+ */
+@Subject(InlineTagRenderCollector)
+class InlineTagRenderCollectorSpec extends Specification {
+
+    public static final String ORIGIN_MARKUP = "origin-markup"
+
+    @Unroll
+    def "what happens with registered render(s): #itrs?"() {
+        given: "create an InlineTagRender collector"
+        def collector = new InlineTagRenderCollector();
+
+        and: "register InlineTagRender(s) (#itrs)"
+        itrs.each {
+            collector.register(it)
+        }
+
+        when: "render the markup"
+        def markdown=collector.render(ORIGIN_MARKUP)
+
+        then: "all renders should be applied in registered order (and applied on the previous outcome)"
+        markdown==expected
+
+        where:
+        itrs                          || expected
+        []                            || "${ORIGIN_MARKUP}"
+        [itr("1st")]                  || "1st(${ORIGIN_MARKUP})"
+        [itr("1st"), itr("2nd")]      || "2nd(1st(${ORIGIN_MARKUP}))"
+        [itr("2nd"), itr("1st")]      || "1st(2nd(${ORIGIN_MARKUP}))"
+    }
+
+    private InlineTagRender itr(String itrName) {
+        return Stub(InlineTagRender) { InlineTagRender inlineTagRender ->
+            inlineTagRender.render(_) >> { String markup -> "${itrName}(${markup})"}
+            inlineTagRender.toString() >> { "ITR(${itrName})" }
+        }
+    }
+}

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/InlineTagRendersSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/InlineTagRendersSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag
+
+import ch.raffael.doclets.pegdown.Options
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * InlineTagRendersSpec contains specification for ... .
+ */
+class InlineTagRendersSpec extends Specification {
+
+    @Unroll
+    def "What happens applying standard renders on '#markup'?"() {
+        given: "standard render"
+        def render = InlineTagRenders.standardRenders(new Options())
+
+        when: "apply render on #markup"
+        def markdown = render.render(markup)
+
+        then: "should result in expected markdown"
+        markdown == expected
+
+        where:
+        markup                                     || expected
+        ""                                         || ""
+        "any text"                                 || "any text"
+        "{@gist feafcf888d949627001948b8346e0da7}" || validGist()
+        "{@gist invalid-gist-id}"                  || invalidGist('invalid-gist-id')
+        "{@gist }"                                 || invalidGist('')
+        "{@gist}"                                  || "{@gist}"
+    }
+
+    static validGist() {
+        return """
+                  |```java
+                  |/**
+                  | * Java doc
+                  | */
+                  |@AnyAnnotation
+                  |public class MyClass {
+                  |  // Any method
+                  |}
+                  |```
+                  |[Gist on Github](https://gist.github.com/feafcf888d949627001948b8346e0da7) and [Raw File GistTest.java](https://gist.githubusercontent.com/loddar/feafcf888d949627001948b8346e0da7/raw/f1f351b465132dc935fe46253cf5249de2e0935c/GistTest.java)
+                  """.stripMargin().trim()
+    }
+
+    static invalidGist(String gistid) {
+        return """
+                  |```
+                  |No gist found for gistid '${gistid}'
+                  |```
+                  |[Gist on Github](https://api.github.com/gists/${gistid}) and [Raw File unknown](https://api.github.com/gists/${gistid})
+               """.stripMargin().trim()
+    }
+}

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistClientSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistClientSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.raffael.doclets.pegdown.inlinetag.gist
+
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ * GistClientSpec contains specification for ... .
+ */
+class GistClientSpec extends Specification {
+
+    private static final String GIST_ID = '3de90e0ff4886ec145e8'
+
+    private URL resolveGithubResponse(String resource) {
+        this.getClass().getResource(resource)
+    }
+
+    def "What happens on valid gist ID?"() {
+        given: "Gist client using a gist-example"
+        def gistClient=new GistRestClient(resolveGithubResponse("gist-valid-example.json"), GIST_ID);
+
+        when: "resolve the gists"
+        def gistItems=gistClient.resolveGists()
+
+        then: "should return expect gist items"
+        gistItems==[expectedGistItem('GeofenceListenerImpl.java'), expectedGistItem('GeofenceSample.java')]
+    }
+
+    @Unroll
+    def "What happens if Github changes JSON (#invalidJsonFile) - invalid field #field?"() {
+        given: "Gist client using a invalid-gist-example"
+        def gistid = GIST_ID
+        def gistClient=new GistRestClient(resolveGithubResponse(invalidJsonFile), gistid);
+
+        when: "resolve the gists"
+        def gistItems=gistClient.resolveGists()
+
+        then: "should be one error gist item"
+        gistItems.size() == 1
+
+        and: "appropriate error message"
+        gistItems.each {
+            assertErrorGistItem(
+                    it,
+                    gistid,
+                    "Parse error: Field '${field}' not found or value is null. Github changes the for GIST-REST-API (using https://api.github.com/gists/${gistid})"
+            )
+        }
+
+        where:
+        field      | invalidJsonFile
+        "id"       | "invalid-gist-example-id.json"
+        "html_url" | "invalid-gist-example-html-url.json"
+        "files"    | "invalid-gist-example-files.json"
+        "filename" | "invalid-gist-example-filename.json"
+        "language" | "invalid-gist-example-language.json"
+        "raw_url"  | "invalid-gist-example-raw-url.json"
+        "content"  | "invalid-gist-example-content.json"
+    }
+
+    // @Ignore("Disable if you have access to github and time ;-)")
+    def "What happens to existing gist (using Gitgub)?"() {
+        given: "Standard Gist client"
+        GistClient gistClient=GistRestClient.standardGistClient()
+
+        and: "valid GIST ID"
+        def gistid = "feafcf888d949627001948b8346e0da7"
+
+        when: "resolve the gists"
+        def gistItems=gistClient.resolveGists(gistid)
+
+        then: "should get expected gist item"
+        gistItems==[expectedGistItem(gistid, 'GistTest.java')]
+    }
+
+    // @Ignore("Disable if you have access to github and time ;-)")
+    def "What happens with invalid GIST ID (using Github)?"() {
+        given: "Standard Gist client"
+        GistClient gistClient=GistRestClient.standardGistClient()
+
+        and: "invalid GIST ID"
+        def gistid = "invalid-gist-id"
+
+        when: "resolve the gists"
+        def gistItems=gistClient.resolveGists(gistid)
+
+        then: "should be exactly one (error) gist item"
+        gistItems.size() == 1
+
+        and: "which should contain"
+        gistItems.each {
+            assertErrorGistItem(it, gistid, "No gist found for gistid '${gistid}'")
+        }
+    }
+
+    private static void assertErrorGistItem(GistItem gistItem, String gistid, String expectedErrorMessage) {
+        assert gistItem.id == gistid
+        assert gistItem.filename == 'unknown'
+        assert gistItem.language == ''
+        assert gistItem.rawUrl == "https://api.github.com/gists/${gistid}".toString()
+        assert gistItem.htmlUrl == "https://api.github.com/gists/${gistid}".toString()
+        assert gistItem.content == expectedErrorMessage
+    }
+
+    private static GistItem expectedGistItem(String filename) {
+        return expectedGistItem(GIST_ID, filename)
+    }
+
+    private static GistItem expectedGistItem(String gistid, String filename) {
+        return new GistItem(gistid, "don't care", filename, "don't care", "don't care", "don't care")
+    }
+}

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagContentConverterSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagContentConverterSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package ch.raffael.doclets.pegdown.inlinetag.gist
+
+import spock.lang.Specification
+
+/**
+ * GistTagContentConverterSpec contains specification for ... .
+ */
+class GistTagContentConverterSpec extends Specification {
+    def "What is the render result from one gist?"() {
+        given: "gist client"
+        def gistClient=Stub(GistClient) {
+            it.resolveGists(_) >> { String gistid ->
+                [                                                                                       //
+                    new GistItem(                                                                       //
+                            gistid,                                                                     //
+                            "https://gist.github.com/${gistid}",                                        //
+                            'GeofenceListenerImpl.java',                                                //
+                            'Java',                                                                     //
+                            "https://gist.githubusercontent.com/${gistid}/GeofenceListenerImpl.java",   //
+                            'Any content of GeofenceListenerImpl.java\n\nA new line.'                   //
+                    )
+                ]
+            }
+        }
+
+        and: "a gist markdown"
+        def gistMarkdown=new GistTagContentConverter(gistClient)
+
+        when: "applying markdown converter"
+        def markdown=gistMarkdown.markdown("123456")
+
+        then: "one code markdown with two links (one to the gist and the second to the raw file)"
+        markdown == """
+                      |```java
+                      |Any content of GeofenceListenerImpl.java
+                      |
+                      |A new line.
+                      |```
+                      |[Gist on Github](https://gist.github.com/123456) and [Raw File GeofenceListenerImpl.java](https://gist.githubusercontent.com/123456/GeofenceListenerImpl.java)
+                    """.stripMargin().trim()
+    }
+
+
+    def "What is the render result from multiple gists?"() {
+        given: "gist client"
+        def gistClient=Stub(GistClient) {
+            it.resolveGists(_) >> { String gistid ->
+                [
+                    new GistItem(gistid,
+                            "https://gist.github.com/${gistid}",                                         //
+                            'GeofenceListenerImpl.java',                                                 //
+                            'Java',                                                                      //
+                            "https://gist.githubusercontent.com/${gistid}/GeofenceListenerImpl.java",    //
+                            'A example in Java'                                                          //
+                    ),                                                                                   //
+                    new GistItem(gistid,                                                                 //
+                            "https://gist.github.com/${gistid}",                                         //
+                            'GeofenceListenerImpl.scala',                                                //
+                            'Scala',                                                                     //
+                            "https://gist.githubusercontent.com/${gistid}/GeofenceListenerImpl.scala",   //
+                            'A example in Scala'                                                         //
+                    )                                                                                    //
+                ]
+            }
+        }
+
+        and: "a gist markdown"
+        def gistMarkdown=new GistTagContentConverter(gistClient)
+
+        when: "applying markdown converter"
+        def markdown=gistMarkdown.markdown("123456")
+
+        then: "should result in multiple code markdowns and links"
+        markdown == """
+                    |```java
+                    |A example in Java
+                    |```
+                    |[Gist on Github](https://gist.github.com/123456) and [Raw File GeofenceListenerImpl.java](https://gist.githubusercontent.com/123456/GeofenceListenerImpl.java)
+                    |
+                    |```scala
+                    |A example in Scala
+                    |```
+                    |[Gist on Github](https://gist.github.com/123456) and [Raw File GeofenceListenerImpl.scala](https://gist.githubusercontent.com/123456/GeofenceListenerImpl.scala)
+                    """.stripMargin().trim()
+    }
+}

--- a/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRenderSpec.groovy
+++ b/doclet/src/test/groovy/ch/raffael/doclets/pegdown/inlinetag/gist/GistTagRenderSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 Raffael Herzog / Marko Umek
+ *
+ * This file is part of pegdown-doclet.
+ *
+ * pegdown-doclet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pegdown-doclet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pegdown-doclet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package ch.raffael.doclets.pegdown.inlinetag.gist
+
+import ch.raffael.doclets.pegdown.inlinetag.TagContentConverter
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * InlineTagRenderCollector contains specification for ... .
+ */
+class GistTagRenderSpec extends Specification {
+
+    @Unroll
+    def "What is the result of rendering '#markup'?"() {
+        given: "a gist markdown converter (stub)"
+        def markdownConverter = Stub(TagContentConverter) {
+            markdown(_) >> { String gistid -> "\ngist ${gistid}\n" }
+        }
+
+        and: "a gist renderer"
+        def renderer = new GistTagRender(markdownConverter)
+
+        when: "render #markup"
+        def markdown=renderer.render(markup)
+
+        then: "should be the expected markdown"
+        markdown==expected
+
+        where:
+        markup                                            || expected
+        "This is normal text"                             || "This is normal text"
+        "{@gist 123456}"                                  || "\ngist 123456"
+        "This is {@gist 123456} a gist"                   || "This is\ngist 123456\na gist"
+        "This is\n{@gist 123456}\na gist"                 || "This is\ngist 123456\na gist"
+        "This is\n{@gist 123456}\na gist {@gist 7865431}" || "This is\ngist 123456\na gist\ngist 7865431"
+    }
+
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/gist-valid-example.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/gist-valid-example.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-content.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-content.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      ">>>content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-filename.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-filename.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      ">>>filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-files.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-files.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  ">>>files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-html-url.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-html-url.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  ">>>html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-id.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-id.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  ">>>id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-language.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-language.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      ">>>language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}

--- a/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-raw-url.json
+++ b/doclet/src/test/resources/ch/raffael/doclets/pegdown/inlinetag/gist/invalid-gist-example-raw-url.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://api.github.com/gists/3de90e0ff4886ec145e8",
+  "forks_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/forks",
+  "commits_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/commits",
+  "id": "3de90e0ff4886ec145e8",
+  "git_pull_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "git_push_url": "https://gist.github.com/3de90e0ff4886ec145e8.git",
+  "html_url": "https://gist.github.com/3de90e0ff4886ec145e8",
+  "files": {
+    "GeofenceListenerImpl.java": {
+      "filename": "GeofenceListenerImpl.java",
+      "type": "text/plain",
+      "language": "Java",
+      ">>>raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/7ee8603422d9eb8c17e3ee01d8dafc149426e52d/GeofenceListenerImpl.java",
+      "size": 697,
+      "truncated": false,
+      "content": "public class GeofenceListenerImpl implements GeofenceListener {\n    @Override\n    public void onExit(String id) {\n    }\n\n    @Override\n    public void onEntered(String id) {\n        if(Display.getInstance().isMinimized()) {\n            Display.getInstance().callSerially(() -> {\n                Dialog.show(\"Welcome\", \"Thanks for arriving\", \"OK\", null);\n            });\n        } else {\n            LocalNotification ln = new LocalNotification();\n            ln.setId(\"LnMessage\");\n            ln.setAlertTitle(\"Welcome\");\n            ln.setAlertBody(\"Thanks for arriving!\");\n            Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);\n        }\n    }    \n}"
+    },
+    "GeofenceSample.java": {
+      "filename": "GeofenceSample.java",
+      "type": "text/plain",
+      "language": "Java",
+      "raw_url": "https://gist.githubusercontent.com/codenameone/3de90e0ff4886ec145e8/raw/cefa007f9893f156ef04171f0535911a1cf41027/GeofenceSample.java",
+      "size": 137,
+      "truncated": false,
+      "content": "Geofence gf = new Geofence(\"test\", loc, 100, 100000);\nLocationManager.getLocationManager().addGeoFencing(GeofenceListenerImpl.class, gf);"
+    }
+  },
+  "public": true,
+  "created_at": "2016-03-05T09:28:26Z",
+  "updated_at": "2016-03-05T09:34:49Z",
+  "description": "Sample usage of the Codename One geofence API to track location",
+  "comments": 1,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/3de90e0ff4886ec145e8/comments",
+  "owner": {
+    "login": "codenameone",
+    "id": 2353641,
+    "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codenameone",
+    "html_url": "https://github.com/codenameone",
+    "followers_url": "https://api.github.com/users/codenameone/followers",
+    "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+    "organizations_url": "https://api.github.com/users/codenameone/orgs",
+    "repos_url": "https://api.github.com/users/codenameone/repos",
+    "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codenameone/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [
+
+  ],
+  "history": [
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "9011c21df52e7747b926738733ffa51b021fe20d",
+      "committed_at": "2016-03-05T09:34:49Z",
+      "change_status": {
+        "total": 2,
+        "additions": 1,
+        "deletions": 1
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/9011c21df52e7747b926738733ffa51b021fe20d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "14d24e39ef0f8511461bd3d04dcde808010bd48d",
+      "committed_at": "2016-03-05T09:33:38Z",
+      "change_status": {
+        "total": 1,
+        "additions": 1,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/14d24e39ef0f8511461bd3d04dcde808010bd48d"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "cfb2061ef1215abc6e64286a116338c3dc4b56a5",
+      "committed_at": "2016-03-05T09:29:02Z",
+      "change_status": {
+        "total": 19,
+        "additions": 19,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/cfb2061ef1215abc6e64286a116338c3dc4b56a5"
+    },
+    {
+      "user": {
+        "login": "codenameone",
+        "id": 2353641,
+        "avatar_url": "https://avatars.githubusercontent.com/u/2353641?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/codenameone",
+        "html_url": "https://github.com/codenameone",
+        "followers_url": "https://api.github.com/users/codenameone/followers",
+        "following_url": "https://api.github.com/users/codenameone/following{/other_user}",
+        "gists_url": "https://api.github.com/users/codenameone/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/codenameone/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/codenameone/subscriptions",
+        "organizations_url": "https://api.github.com/users/codenameone/orgs",
+        "repos_url": "https://api.github.com/users/codenameone/repos",
+        "events_url": "https://api.github.com/users/codenameone/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/codenameone/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "728d3a5675b7f1f541819a73a0ecc0146cba7a80",
+      "committed_at": "2016-03-05T09:28:26Z",
+      "change_status": {
+        "total": 2,
+        "additions": 2,
+        "deletions": 0
+      },
+      "url": "https://api.github.com/gists/3de90e0ff4886ec145e8/728d3a5675b7f1f541819a73a0ecc0146cba7a80"
+    }
+  ],
+  "truncated": false
+}


### PR DESCRIPTION
Changes:

- Add groovy-all to doclet/build.gradle
- adapt .gitignore
- Refactor Options and PegdownDoclet: Move the toHtmll() from Options to the doclet.
- Implement gist-inline-tag (issue #58) and integrate it in PegdownDoclet
- New packages in doclet:
     - ch.raffael.doclets.pegdown.inlinetag
     - ch.raffael.doclets.pegdown.inlinetag.gist
